### PR TITLE
Add fork versioning strategy, branching policy, and changelog for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,9 @@
-You can find all changes on the Releases page here: https://github.com/moov-io/iso8583/releases
+You can find all changes on the Releases page here: https://github.com/b365tech/iso8583/releases
+
+# Changelog
+
+## [v1.0.0]
+
+Initial release of the Banc365 fork.
+
+- Based on upstream tag: [moov-io/iso8583@v0.23.4](https://github.com/moov-io/iso8583/releases/tag/v0.23.4)

--- a/README.md
+++ b/README.md
@@ -720,18 +720,32 @@ As part of Moov's initiative to offer open source fintech infrastructure, we hav
 
 Apache License 2.0 - See [LICENSE](LICENSE) for details.
 
-## Fork Versioning
+## Fork Versioning & Branch Strategy
 
-This fork of [moov-io/iso8583](https://github.com/moov-io/iso8583) uses its **own semantic versioning**, starting at `v1.0.0`.
+This repository is a fork of [moov-io/iso8583](https://github.com/moov-io/iso8583).
 
-Our versioning follows the standard [Semantic Versioning](https://semver.org/) convention:
+We use our **own semantic versioning**, starting at `v1.0.0`, to track internal releases.
 
+### Fork Branches
+
+- `master`: Mirrors the latest changes from the upstream Moov repository.
+- `banc365-main`: Used for internal development, tagging, and versioned releases.
+
+All development and version tagging happens on `banc365-main`.
+
+### Fork Upstream Base
+
+Our first release, `v1.0.0`, is based on upstream tag [`v0.23.4`](https://github.com/moov-io/iso8583/releases/tag/v0.23.4). Releases will note their upstream base in the [CHANGELOG](./CHANGELOG.md).
+
+---
+
+## Fork Installation
+
+To install the library with a custom tag from this fork, use the following in your `go.mod` file:
+
+```go
+require github.com/moov-io/iso8583 v1.0.0
+replace github.com/moov-io/iso8583 => github.com/b365tech/iso8583 v1.0.0
 ```
-MAJOR.MINOR.PATCH
-```
 
-- We increment **MAJOR** when we make incompatible API or behavior changes.
-- We increment **MINOR** when we add functionality in a backwards-compatible manner.
-- We increment **PATCH** when we make backwards-compatible bug fixes.
-
-Each release in our fork will indicate the Moov tag or commit it was derived from in the [CHANGELOG](./CHANGELOG.md).
+This allows you to use our tagged versions under the original `moov-io/iso8583` import path, ensuring compatibility with your existing code.

--- a/README.md
+++ b/README.md
@@ -719,3 +719,19 @@ As part of Moov's initiative to offer open source fintech infrastructure, we hav
 ## License
 
 Apache License 2.0 - See [LICENSE](LICENSE) for details.
+
+## Fork Versioning
+
+This fork of [moov-io/iso8583](https://github.com/moov-io/iso8583) uses its **own semantic versioning**, starting at `v1.0.0`.
+
+Our versioning follows the standard [Semantic Versioning](https://semver.org/) convention:
+
+```
+MAJOR.MINOR.PATCH
+```
+
+- We increment **MAJOR** when we make incompatible API or behavior changes.
+- We increment **MINOR** when we add functionality in a backwards-compatible manner.
+- We increment **PATCH** when we make backwards-compatible bug fixes.
+
+Each release in our fork will indicate the Moov tag or commit it was derived from in the [CHANGELOG](./CHANGELOG.md).


### PR DESCRIPTION
### Summary

This PR introduces documentation to clearly define the versioning and branching strategy for the Banc365 fork of `moov-io/iso8583`.

### Changes

- Updated `README.md` to include:
  - Fork-specific semantic versioning starting at `v1.0.0`
  - Branching policy: `master` mirrors upstream; `banc365-main` is used for releases
  - Installation instructions using `go.mod` with `replace` directive
  - Reference to upstream base tag `v0.23.4`

- Added initial `CHANGELOG.md` with:
  - Entry for `v1.0.0`
  - Link to upstream version this release is based on

This provides clarity for future maintainers, ensures consistency in releases, and makes integration easier for other teams consuming this library.

---

### Related

- Based on upstream tag: [moov-io/iso8583@v0.23.4](https://github.com/moov-io/iso8583/releases/tag/v0.23.4)
